### PR TITLE
fix the actuator order to follow the same convention as the joint

### DIFF
--- a/gym_quadruped/robot_model/aliengo/aliengo.xml
+++ b/gym_quadruped/robot_model/aliengo/aliengo.xml
@@ -203,48 +203,48 @@
         </body>
     </worldbody>
 
-    <actuator>
-        <motor name="FR_hip" class="hip" gear="1" joint="FR_hip_joint"/>
-        <motor name="FR_thigh" class="thigh" gear="1" joint="FR_thigh_joint"/>
-        <motor name="FR_calf" class="calf" gear="1" joint="FR_calf_joint"/>
-        <motor name="FL_hip" class="hip" gear="1" joint="FL_hip_joint"/>
-        <motor name="FL_thigh" class="thigh" gear="1" joint="FL_thigh_joint"/>
-        <motor name="FL_calf" class="calf" gear="1" joint="FL_calf_joint"/>
-        <motor name="RR_hip" class="hip" gear="1" joint="RR_hip_joint"/>
-        <motor name="RR_thigh" class="thigh" gear="1" joint="RR_thigh_joint"/>
-        <motor name="RR_calf" class="calf" gear="1" joint="RR_calf_joint"/>
-        <motor name="RL_hip" class="hip" gear="1" joint="RL_hip_joint"/>
-        <motor name="RL_thigh" class="thigh" gear="1" joint="RL_thigh_joint"/>
-        <motor name="RL_calf" class="calf" gear="1" joint="RL_calf_joint"/>
+    <actuator>       
+        <motor name="FL_hip"   class="hip"    gear="1" joint="FL_hip_joint"/>
+        <motor name="FL_thigh" class="thigh"  gear="1" joint="FL_thigh_joint"/>
+        <motor name="FL_calf"  class="calf"   gear="1" joint="FL_calf_joint"/>
+         <motor name="FR_hip"   class="hip"    gear="1" joint="FR_hip_joint"/>
+        <motor name="FR_thigh" class="thigh"  gear="1" joint="FR_thigh_joint"/>
+        <motor name="FR_calf"  class="calf"   gear="1" joint="FR_calf_joint"/>
+        <motor name="RL_hip"   class="hip"    gear="1" joint="RL_hip_joint"/>
+        <motor name="RL_thigh" class="thigh"  gear="1" joint="RL_thigh_joint"/>
+        <motor name="RL_calf"  class="calf"   gear="1" joint="RL_calf_joint"/>
+        <motor name="RR_hip"   class="hip"    gear="1" joint="RR_hip_joint"/>
+        <motor name="RR_thigh" class="thigh"  gear="1" joint="RR_thigh_joint"/>
+        <motor name="RR_calf"  class="calf"   gear="1" joint="RR_calf_joint" />
     </actuator>
 
     <sensor>
 
-        <jointpos name="FR_hip_pos" joint="FR_hip_joint"/>
-        <jointpos name="FR_thigh_pos" joint="FR_thigh_joint"/>
-        <jointpos name="FR_calf_pos" joint="FR_calf_joint"/>
-        <jointpos name="FL_hip_pos" joint="FL_hip_joint"/>
-        <jointpos name="FL_thigh_pos" joint="FL_thigh_joint"/>
-        <jointpos name="FL_calf_pos" joint="FL_calf_joint"/>
-        <jointpos name="RR_hip_pos" joint="RR_hip_joint"/>
-        <jointpos name="RR_thigh_pos" joint="RR_thigh_joint"/>
-        <jointpos name="RR_calf_pos" joint="RR_calf_joint"/>
-        <jointpos name="RL_hip_pos" joint="RL_hip_joint"/>
-        <jointpos name="RL_thigh_pos" joint="RL_thigh_joint"/>
-        <jointpos name="RL_calf_pos" joint="RL_calf_joint"/>
+        <jointpos name="FL_hip_pos"     joint="FL_hip_joint"/>
+        <jointpos name="FL_thigh_pos"   joint="FL_thigh_joint"/>
+        <jointpos name="FL_calf_pos"    joint="FL_calf_joint"/>
+        <jointpos name="FR_hip_pos"     joint="FR_hip_joint"/>
+        <jointpos name="FR_thigh_pos"   joint="FR_thigh_joint"/>
+        <jointpos name="FR_calf_pos"    joint="FR_calf_joint"/>
+        <jointpos name="RL_hip_pos"     joint="RL_hip_joint"/>
+        <jointpos name="RL_thigh_pos"   joint="RL_thigh_joint"/>
+        <jointpos name="RL_calf_pos"    joint="RL_calf_joint"/>
+        <jointpos name="RR_hip_pos"     joint="RR_hip_joint"/>
+        <jointpos name="RR_thigh_pos"   joint="RR_thigh_joint"/>
+        <jointpos name="RR_calf_pos"    joint="RR_calf_joint" />
 
-        <jointvel name="FR_hip_vel" joint="FR_hip_joint"/>
-        <jointvel name="FR_thigh_vel" joint="FR_thigh_joint"/>
-        <jointvel name="FR_calf_vel" joint="FR_calf_joint"/>
-        <jointvel name="FL_hip_vel" joint="FL_hip_joint"/>
-        <jointvel name="FL_thigh_vel" joint="FL_thigh_joint"/>
-        <jointvel name="FL_calf_vel" joint="FL_calf_joint"/>
-        <jointvel name="RR_hip_vel" joint="RR_hip_joint"/>
-        <jointvel name="RR_thigh_vel" joint="RR_thigh_joint"/>
-        <jointvel name="RR_calf_vel" joint="RR_calf_joint"/>
-        <jointvel name="RL_hip_vel" joint="RL_hip_joint"/>
-        <jointvel name="RL_thigh_vel" joint="RL_thigh_joint"/>
-        <jointvel name="RL_calf_vel" joint="RL_calf_joint"/>
+        <jointvel name="FL_hip_vel"     joint="FL_hip_joint"/>
+        <jointvel name="FL_thigh_vel"   joint="FL_thigh_joint"/>
+        <jointvel name="FL_calf_vel"    joint="FL_calf_joint"/>
+         <jointvel name="FR_hip_vel"     joint="FR_hip_joint"/>
+        <jointvel name="FR_thigh_vel"   joint="FR_thigh_joint"/>
+        <jointvel name="FR_calf_vel"    joint="FR_calf_joint"/>
+        <jointvel name="RL_hip_vel"     joint="RL_hip_joint"/>
+        <jointvel name="RL_thigh_vel"   joint="RL_thigh_joint"/>
+        <jointvel name="RL_calf_vel"    joint="RL_calf_joint"/>
+        <jointvel name="RR_hip_vel"     joint="RR_hip_joint"/>
+        <jointvel name="RR_thigh_vel"   joint="RR_thigh_joint"/>
+        <jointvel name="RR_calf_vel"    joint="RR_calf_joint" />
 
         <accelerometer name="Body_Acc" site="imu"/>
 

--- a/gym_quadruped/robot_model/b2/b2.xml
+++ b/gym_quadruped/robot_model/b2/b2.xml
@@ -231,59 +231,61 @@
     </worldbody>
 
     <actuator>
-        <motor class="b2" ctrlrange="-200 200" name="FR_hip" joint="FR_hip_joint"/>
-        <motor class="b2" ctrlrange="-200 200" name="FR_thigh" joint="FR_thigh_joint"/>
-        <motor class="b2" ctrlrange="-300 300" name="FR_calf" joint="FR_calf_joint"/>
         <motor class="b2" ctrlrange="-200 200" name="FL_hip" joint="FL_hip_joint"/>
         <motor class="b2" ctrlrange="-200 200" name="FL_thigh" joint="FL_thigh_joint"/>
         <motor class="b2" ctrlrange="-300 300" name="FL_calf" joint="FL_calf_joint"/>
-        <motor class="b2" ctrlrange="-200 200" name="RR_hip" joint="RR_hip_joint"/>
-        <motor class="b2" ctrlrange="-200 200" name="RR_thigh" joint="RR_thigh_joint"/>
-        <motor class="b2" ctrlrange="-300 300" name="RR_calf" joint="RR_calf_joint"/>
+        <motor class="b2" ctrlrange="-200 200" name="FR_hip" joint="FR_hip_joint"/>
+        <motor class="b2" ctrlrange="-200 200" name="FR_thigh" joint="FR_thigh_joint"/>
+        <motor class="b2" ctrlrange="-300 300" name="FR_calf" joint="FR_calf_joint"/>
         <motor class="b2" ctrlrange="-200 200" name="RL_hip" joint="RL_hip_joint"/>
         <motor class="b2" ctrlrange="-200 200" name="RL_thigh" joint="RL_thigh_joint"/>
         <motor class="b2" ctrlrange="-300 300" name="RL_calf" joint="RL_calf_joint"/>
+        <motor class="b2" ctrlrange="-200 200" name="RR_hip" joint="RR_hip_joint"/>
+        <motor class="b2" ctrlrange="-200 200" name="RR_thigh" joint="RR_thigh_joint"/>
+        <motor class="b2" ctrlrange="-300 300" name="RR_calf" joint="RR_calf_joint"/>
     </actuator>
 
     <sensor>
-        <jointpos name="FR_hip_pos" joint="FR_hip_joint"/>
-        <jointpos name="FR_thigh_pos" joint="FR_thigh_joint"/>
-        <jointpos name="FR_calf_pos" joint="FR_calf_joint"/>
         <jointpos name="FL_hip_pos" joint="FL_hip_joint"/>
         <jointpos name="FL_thigh_pos" joint="FL_thigh_joint"/>
         <jointpos name="FL_calf_pos" joint="FL_calf_joint"/>
-        <jointpos name="RR_hip_pos" joint="RR_hip_joint"/>
-        <jointpos name="RR_thigh_pos" joint="RR_thigh_joint"/>
-        <jointpos name="RR_calf_pos" joint="RR_calf_joint"/>
+        <jointpos name="FR_hip_pos" joint="FR_hip_joint"/>
+        <jointpos name="FR_thigh_pos" joint="FR_thigh_joint"/>
+        <jointpos name="FR_calf_pos" joint="FR_calf_joint"/>
         <jointpos name="RL_hip_pos" joint="RL_hip_joint"/>
         <jointpos name="RL_thigh_pos" joint="RL_thigh_joint"/>
         <jointpos name="RL_calf_pos" joint="RL_calf_joint"/>
+        <jointpos name="RR_hip_pos" joint="RR_hip_joint"/>
+        <jointpos name="RR_thigh_pos" joint="RR_thigh_joint"/>
+        <jointpos name="RR_calf_pos" joint="RR_calf_joint"/>
 
-        <jointvel name="FR_hip_vel" joint="FR_hip_joint"/>
-        <jointvel name="FR_thigh_vel" joint="FR_thigh_joint"/>
-        <jointvel name="FR_calf_vel" joint="FR_calf_joint"/>
+        
         <jointvel name="FL_hip_vel" joint="FL_hip_joint"/>
         <jointvel name="FL_thigh_vel" joint="FL_thigh_joint"/>
         <jointvel name="FL_calf_vel" joint="FL_calf_joint"/>
-        <jointvel name="RR_hip_vel" joint="RR_hip_joint"/>
-        <jointvel name="RR_thigh_vel" joint="RR_thigh_joint"/>
-        <jointvel name="RR_calf_vel" joint="RR_calf_joint"/>
+        <jointvel name="FR_hip_vel" joint="FR_hip_joint"/>
+        <jointvel name="FR_thigh_vel" joint="FR_thigh_joint"/>
+        <jointvel name="FR_calf_vel" joint="FR_calf_joint"/>
         <jointvel name="RL_hip_vel" joint="RL_hip_joint"/>
         <jointvel name="RL_thigh_vel" joint="RL_thigh_joint"/>
         <jointvel name="RL_calf_vel" joint="RL_calf_joint"/>
+        <jointvel name="RR_hip_vel" joint="RR_hip_joint"/>
+        <jointvel name="RR_thigh_vel" joint="RR_thigh_joint"/>
+        <jointvel name="RR_calf_vel" joint="RR_calf_joint"/>
 
-        <jointactuatorfrc name="FR_hip_torque" joint="FR_hip_joint" noise="0.01"/>
-        <jointactuatorfrc name="FR_thigh_torque" joint="FR_thigh_joint" noise="0.01"/>
-        <jointactuatorfrc name="FR_calf_torque" joint="FR_calf_joint" noise="0.01"/>
+
         <jointactuatorfrc name="FL_hip_torque" joint="FL_hip_joint" noise="0.01"/>
         <jointactuatorfrc name="FL_thigh_torque" joint="FL_thigh_joint" noise="0.01"/>
         <jointactuatorfrc name="FL_calf_torque" joint="FL_calf_joint" noise="0.01"/>
-        <jointactuatorfrc name="RR_hip_torque" joint="RR_hip_joint" noise="0.01"/>
-        <jointactuatorfrc name="RR_thigh_torque" joint="RR_thigh_joint" noise="0.01"/>
-        <jointactuatorfrc name="RR_calf_torque" joint="RR_calf_joint" noise="0.01"/>
+        <jointactuatorfrc name="FR_hip_torque" joint="FR_hip_joint" noise="0.01"/>
+        <jointactuatorfrc name="FR_thigh_torque" joint="FR_thigh_joint" noise="0.01"/>
+        <jointactuatorfrc name="FR_calf_torque" joint="FR_calf_joint" noise="0.01"/>
         <jointactuatorfrc name="RL_hip_torque" joint="RL_hip_joint" noise="0.01"/>
         <jointactuatorfrc name="RL_thigh_torque" joint="RL_thigh_joint" noise="0.01"/>
         <jointactuatorfrc name="RL_calf_torque" joint="RL_calf_joint" noise="0.01"/>
+        <jointactuatorfrc name="RR_hip_torque" joint="RR_hip_joint" noise="0.01"/>
+        <jointactuatorfrc name="RR_thigh_torque" joint="RR_thigh_joint" noise="0.01"/>
+        <jointactuatorfrc name="RR_calf_torque" joint="RR_calf_joint" noise="0.01"/>
 
         <framequat name="imu_quat" objtype="site" objname="imu"/>
         <gyro name="imu_gyro" site="imu"/>
@@ -299,3 +301,4 @@
     </keyframe>
 
 </mujoco>
+

--- a/gym_quadruped/robot_model/go1/go1.xml
+++ b/gym_quadruped/robot_model/go1/go1.xml
@@ -214,18 +214,18 @@
     </worldbody>
 
     <actuator>
-        <motor class="abduction" name="FR_hip" joint="FR_hip_joint"/>
-        <motor class="hip" name="FR_thigh" joint="FR_thigh_joint"/>
-        <motor class="knee" name="FR_calf" joint="FR_calf_joint"/>
         <motor class="abduction" name="FL_hip" joint="FL_hip_joint"/>
         <motor class="hip" name="FL_thigh" joint="FL_thigh_joint"/>
         <motor class="knee" name="FL_calf" joint="FL_calf_joint"/>
-        <motor class="abduction" name="RR_hip" joint="RR_hip_joint"/>
-        <motor class="hip" name="RR_thigh" joint="RR_thigh_joint"/>
-        <motor class="knee" name="RR_calf" joint="RR_calf_joint"/>
+         <motor class="abduction" name="FR_hip" joint="FR_hip_joint"/>
+        <motor class="hip" name="FR_thigh" joint="FR_thigh_joint"/>
+        <motor class="knee" name="FR_calf" joint="FR_calf_joint"/>
         <motor class="abduction" name="RL_hip" joint="RL_hip_joint"/>
         <motor class="hip" name="RL_thigh" joint="RL_thigh_joint"/>
         <motor class="knee" name="RL_calf" joint="RL_calf_joint"/>
+        <motor class="abduction" name="RR_hip" joint="RR_hip_joint"/>
+        <motor class="hip" name="RR_thigh" joint="RR_thigh_joint"/>
+        <motor class="knee" name="RR_calf" joint="RR_calf_joint"/>
     </actuator>
 
     <keyframe>
@@ -233,3 +233,4 @@
              ctrl="0 0.9 -1.8 0 0.9 -1.8 0 0.9 -1.8 0 0.9 -1.8"/>
     </keyframe>
 </mujoco>
+

--- a/gym_quadruped/robot_model/go2/go2.xml
+++ b/gym_quadruped/robot_model/go2/go2.xml
@@ -200,18 +200,18 @@
     </worldbody>
 
     <actuator>
-        <motor class="abduction" name="FR_hip" joint="FR_hip_joint"/>
-        <motor class="hip" name="FR_thigh" joint="FR_thigh_joint"/>
-        <motor class="knee" name="FR_calf" joint="FR_calf_joint"/>
         <motor class="abduction" name="FL_hip" joint="FL_hip_joint"/>
         <motor class="hip" name="FL_thigh" joint="FL_thigh_joint"/>
         <motor class="knee" name="FL_calf" joint="FL_calf_joint"/>
-        <motor class="abduction" name="RR_hip" joint="RR_hip_joint"/>
-        <motor class="hip" name="RR_thigh" joint="RR_thigh_joint"/>
-        <motor class="knee" name="RR_calf" joint="RR_calf_joint"/>
+        <motor class="abduction" name="FR_hip" joint="FR_hip_joint"/>
+        <motor class="hip" name="FR_thigh" joint="FR_thigh_joint"/>
+        <motor class="knee" name="FR_calf" joint="FR_calf_joint"/>
         <motor class="abduction" name="RL_hip" joint="RL_hip_joint"/>
         <motor class="hip" name="RL_thigh" joint="RL_thigh_joint"/>
         <motor class="knee" name="RL_calf" joint="RL_calf_joint"/>
+        <motor class="abduction" name="RR_hip" joint="RR_hip_joint"/>
+        <motor class="hip" name="RR_thigh" joint="RR_thigh_joint"/>
+        <motor class="knee" name="RR_calf" joint="RR_calf_joint"/>
     </actuator>
 
     <keyframe>
@@ -219,3 +219,4 @@
              ctrl="0 0.9 -1.8 0 0.9 -1.8 0 0.9 -1.8 0 0.9 -1.8"/>
     </keyframe>
 </mujoco>
+

--- a/gym_quadruped/robot_model/hyqreal/hyqreal.xml
+++ b/gym_quadruped/robot_model/hyqreal/hyqreal.xml
@@ -184,31 +184,31 @@
     </worldbody>
 
     <sensor>
-        <jointpos name="FR_hip_pos" joint="FR_hip_joint"/>
-        <jointpos name="FR_thigh_pos" joint="FR_thigh_joint"/>
-        <jointpos name="FR_calf_pos" joint="FR_calf_joint"/>
         <jointpos name="FL_hip_pos" joint="FL_hip_joint"/>
         <jointpos name="FL_thigh_pos" joint="FL_thigh_joint"/>
         <jointpos name="FL_calf_pos" joint="FL_calf_joint"/>
-        <jointpos name="RR_hip_pos" joint="RR_hip_joint"/>
-        <jointpos name="RR_thigh_pos" joint="RR_thigh_joint"/>
-        <jointpos name="RR_calf_pos" joint="RR_calf_joint"/>
+        <jointpos name="FR_hip_pos" joint="FR_hip_joint"/>
+        <jointpos name="FR_thigh_pos" joint="FR_thigh_joint"/>
+        <jointpos name="FR_calf_pos" joint="FR_calf_joint"/>
         <jointpos name="RL_hip_pos" joint="RL_hip_joint"/>
         <jointpos name="RL_thigh_pos" joint="RL_thigh_joint"/>
         <jointpos name="RL_calf_pos" joint="RL_calf_joint"/>
+        <jointpos name="RR_hip_pos" joint="RR_hip_joint"/>
+        <jointpos name="RR_thigh_pos" joint="RR_thigh_joint"/>
+        <jointpos name="RR_calf_pos" joint="RR_calf_joint"/>
 
-        <jointvel name="FR_hip_vel" joint="FR_hip_joint"/>
-        <jointvel name="FR_thigh_vel" joint="FR_thigh_joint"/>
-        <jointvel name="FR_calf_vel" joint="FR_calf_joint"/>
         <jointvel name="FL_hip_vel" joint="FL_hip_joint"/>
         <jointvel name="FL_thigh_vel" joint="FL_thigh_joint"/>
         <jointvel name="FL_calf_vel" joint="FL_calf_joint"/>
-        <jointvel name="RR_hip_vel" joint="RR_hip_joint"/>
-        <jointvel name="RR_thigh_vel" joint="RR_thigh_joint"/>
-        <jointvel name="RR_calf_vel" joint="RR_calf_joint"/>
+        <jointvel name="FR_hip_vel" joint="FR_hip_joint"/>
+        <jointvel name="FR_thigh_vel" joint="FR_thigh_joint"/>
+        <jointvel name="FR_calf_vel" joint="FR_calf_joint"/>
         <jointvel name="RL_hip_vel" joint="RL_hip_joint"/>
         <jointvel name="RL_thigh_vel" joint="RL_thigh_joint"/>
         <jointvel name="RL_calf_vel" joint="RL_calf_joint"/>
+        <jointvel name="RR_hip_vel" joint="RR_hip_joint"/>
+        <jointvel name="RR_thigh_vel" joint="RR_thigh_joint"/>
+        <jointvel name="RR_calf_vel" joint="RR_calf_joint"/>
 
         <accelerometer name="Body_Acc" site="imu"/>
         <gyro name="Body_Gyro" site="imu"/>
@@ -219,21 +219,21 @@
 
     <actuator>
 
-        <motor name="FR_hip" ctrlrange="-173.0 173.0" joint="FL_hip_joint"/>
-        <motor name="FR_thigh" ctrlrange="-208 208" joint="FL_thigh_joint"/>
-        <motor name="FR_calf" ctrlrange="-249 249" joint="FL_calf_joint"/>
-
         <motor name="FL_hip" ctrlrange="-173.0 173.0" joint="FR_hip_joint"/>
         <motor name="FL_thigh" ctrlrange="-208 208" joint="FR_thigh_joint"/>
         <motor name="FL_calf" ctrlrange="-249 249" joint="FR_calf_joint"/>
 
-        <motor name="RR_hip" ctrlrange="-173.0 173.0" joint="RR_hip_joint"/>
-        <motor name="RR_thigh" ctrlrange="-208 208" joint="RR_thigh_joint"/>
-        <motor name="RR_calf" ctrlrange="-249 249" joint="RR_calf_joint"/>
+        <motor name="FR_hip" ctrlrange="-173.0 173.0" joint="FL_hip_joint"/>
+        <motor name="FR_thigh" ctrlrange="-208 208" joint="FL_thigh_joint"/>
+        <motor name="FR_calf" ctrlrange="-249 249" joint="FL_calf_joint"/>
 
         <motor name="RL_hip" ctrlrange="-173.0 173.0" joint="RL_hip_joint"/>
         <motor name="RL_thigh" ctrlrange="-208 208" joint="RL_thigh_joint"/>
         <motor name="RL_calf" ctrlrange="-249 249" joint="RL_calf_joint"/>
+
+        <motor name="RR_hip" ctrlrange="-173.0 173.0" joint="RR_hip_joint"/>
+        <motor name="RR_thigh" ctrlrange="-208 208" joint="RR_thigh_joint"/>
+        <motor name="RR_calf" ctrlrange="-249 249" joint="RR_calf_joint"/>
 
     </actuator>
 
@@ -241,3 +241,4 @@
         <key qpos='0 0 0.5 1 0 0 0 0 0.9 -1.7 0 0.9 -1.7 0 0.9 -1.7 0 0.9 -1.7'/>
     </keyframe>
 </mujoco>
+


### PR DESCRIPTION
In all the xml except for mini-cheetah, the joints follow a different order from the actuators. This means that the joint order in mjData.qpos is different from the one in mjData.ctrl. Despite this, it does not create any error, it could cause useless confusion.