### PR TITLE
fix xmls of the robot for a missing character

### DIFF
--- a/gym_quadruped/robot_model/aliengo/aliengo.xml
+++ b/gym_quadruped/robot_model/aliengo/aliengo.xml
@@ -22,7 +22,7 @@
     </default>
 
     <asset>
-        <mesh name="base" file="assets/base.stl"/>
+        <mesh name="base" file="assets/trunk.stl"/>
         <mesh name="hip" file="assets/hip.stl"/>
         <mesh name="thigh_mirror" file="assets/thigh_mirror.stl"/>
         <mesh name="calf" file="assets/calf.stl"/>
@@ -82,7 +82,7 @@
                               quat="0.707107 0 0.707107 0"/>
 
                         <!-- FL_foot only collision -->
-                        <geom name="FL" class="collision" size="0.0265" pos="0 0 -0.25">
+                        <geom name="FL" class="collision" size="0.0265" pos="0 0 -0.25"/>
 
                     </body>
                 </body>
@@ -120,7 +120,7 @@
                               quat="0.707107 0 0.707107 0"/>
 
                         <!-- FR_foot only collision -->
-                        <geom name="FR" class="collision" size="0.0265" pos="0 0 -0.25">
+                        <geom name="FR" class="collision" size="0.0265" pos="0 0 -0.25"/>
 
                     </body>
                 </body>
@@ -158,7 +158,7 @@
                               quat="0.707107 0 0.707107 0"/>
 
                         <!-- RL_foot only collision -->
-                        <geom name="RL" class="collision" size="0.0265" pos="0 0 -0.25">
+                        <geom name="RL" class="collision" size="0.0265" pos="0 0 -0.25"/>
                         
 
                     </body>
@@ -197,7 +197,7 @@
                               quat="0.707107 0 0.707107 0"/>
 
                         <!-- RR_foot only collision -->
-                        <geom name="RR" class="collision" size="0.0265" pos="0 0 -0.25">
+                        <geom name="RR" class="collision" size="0.0265" pos="0 0 -0.25"/>
 
                     </body>
                 </body>

--- a/gym_quadruped/robot_model/go2/go2.xml
+++ b/gym_quadruped/robot_model/go2/go2.xml
@@ -111,7 +111,7 @@
                         <geom pos="0 0 -0.213" mesh="foot" class="visual" material="black"/>
                         
                         <geom name="FL" class="collision" size="0.022" pos="-0.002 0 -0.213" priority="1" condim="6"
-                          friction="0.8 0.02 0.01">
+                          friction="0.8 0.02 0.01"/>
 
                     </body>
                 </body>
@@ -146,7 +146,7 @@
                         <geom pos="0 0 -0.213" mesh="foot" class="visual" material="black"/>
 
                         <geom name="FR" class="collision" size="0.022" pos="-0.002 0 -0.213" priority="1" condim="6"
-                          friction="0.8 0.02 0.01">
+                          friction="0.8 0.02 0.01"/>
 
                     </body>
                 </body>
@@ -182,7 +182,7 @@
                         <geom pos="0 0 -0.213" mesh="foot" class="visual" material="black"/>
 
                         <geom name="RL" class="collision" size="0.022" pos="-0.002 0 -0.213" priority="1" condim="6"
-                          friction="0.8 0.02 0.01">
+                          friction="0.8 0.02 0.01"/>
 
                     </body>
                 </body>
@@ -217,7 +217,7 @@
                         <geom pos="0 0 -0.213" mesh="foot" class="visual" material="black"/>
 
                         <geom name="RR" class="collision" size="0.022" pos="-0.002 0 -0.213" priority="1" condim="6"
-                          friction="0.8 0.02 0.01">
+                          friction="0.8 0.02 0.01"/>
 
                     </body>
                 </body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gym-quadruped"
-version = "1.1.3"
+version = "1.1.4"
 description = "A gym environment for quadruped robots using MuJoCo physics engine."
 authors = [
     { name = "Daniel Ordoñez-Apraez", email = "daniels.ordonez@gmail.com" },


### PR DESCRIPTION
As per title, last commit had the foot as body, which is not supported yet in gym-quadruped. Reverted as simple geoms plus fixed missing character